### PR TITLE
Forwards-compatibility with zend-servicemanager v3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,19 +11,34 @@ cache:
   directories:
     - $HOME/.composer/cache
 
+env:
+  global:
+    - SERVICE_MANAGER_VERSION="^3.0.3"
+
 matrix:
   fast_finish: true
   include:
     - php: 5.5
       env:
         - EXECUTE_CS_CHECK=true
+    - php: 5.5
+      env:
+        - SERVICE_MANAGER_VERSION="^2.7.5"
     - php: 5.6
       env:
         - EXECUTE_TEST_COVERALLS=true
+    - php: 5.6
+      env:
+        - SERVICE_MANAGER_VERSION="^2.7.5"
     - php: 7
+    - php: 7
+      env:
+        - SERVICE_MANAGER_VERSION="^2.7.5"
     - php: hhvm 
+    - php: hhvm 
+      env:
+        - SERVICE_MANAGER_VERSION="^2.7.5"
   allow_failures:
-    - php: 7
     - php: hhvm
 
 notifications:
@@ -34,6 +49,7 @@ before_install:
   - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
   - composer self-update
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
+  - composer require --dev --no-update "zendframework/zend-servicemanager:$SERVICE_MANAGER_VERSION"
 
 install:
   - travis_retry composer install --no-interaction --ignore-platform-reqs

--- a/composer.json
+++ b/composer.json
@@ -13,18 +13,17 @@
         }
     },
     "require": {
-        "php": ">=5.5",
-        "zendframework/zend-stdlib": "dev-develop as 2.8.0"
+        "php": "^5.5 || ^7.0",
+        "zendframework/zend-stdlib": "^2.7 || ^3.0"
     },
     "require-dev": {
-        "zendframework/zend-cache": "dev-develop as 2.6.0",
-        "zendframework/zend-config": "dev-develop as 2.6.0",
-        "zendframework/zend-db": "~2.5",
-        "zendframework/zend-filter": "~2.5",
-        "zendframework/zend-json": "~2.5",
-        "zendframework/zend-mvc": "dev-develop as 2.7.0",
-        "zendframework/zend-servicemanager": "dev-develop as 2.7.0",
-        "zendframework/zend-view": "dev-develop as 2.6.0",
+        "zendframework/zend-cache": "^2.6.1",
+        "zendframework/zend-config": "^2.6.0",
+        "zendframework/zend-db": "^2.7",
+        "zendframework/zend-filter": "^2.6.1",
+        "zendframework/zend-json": "^2.6.1",
+        "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
+        "zendframework/zend-view": "^2.6.3",
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/PHPUnit": "~4.0"
     },

--- a/src/Adapter/Iterator.php
+++ b/src/Adapter/Iterator.php
@@ -9,7 +9,8 @@
 
 namespace Zend\Paginator\Adapter;
 
-use Zend\Paginator;
+use Countable;
+use Zend\Paginator\SerializableLimitIterator;
 
 class Iterator implements AdapterInterface
 {
@@ -31,11 +32,11 @@ class Iterator implements AdapterInterface
      * Constructor.
      *
      * @param  \Iterator $iterator Iterator to paginate
-     * @throws \Zend\Paginator\Adapter\Exception\InvalidArgumentException
+     * @throws Exception\InvalidArgumentException
      */
     public function __construct(\Iterator $iterator)
     {
-        if (!$iterator instanceof \Countable) {
+        if (! $iterator instanceof Countable) {
             throw new Exception\InvalidArgumentException('Iterator must implement Countable');
         }
 
@@ -48,14 +49,14 @@ class Iterator implements AdapterInterface
      *
      * @param  int $offset Page offset
      * @param  int $itemCountPerPage Number of items per page
-     * @return array|\Zend\Paginator\SerializableLimitIterator
+     * @return array|SerializableLimitIterator
      */
     public function getItems($offset, $itemCountPerPage)
     {
         if ($this->count == 0) {
             return [];
         }
-        return new Paginator\SerializableLimitIterator($this->iterator, $offset, $itemCountPerPage);
+        return new SerializableLimitIterator($this->iterator, $offset, $itemCountPerPage);
     }
 
     /**

--- a/src/Adapter/Service/CallbackFactory.php
+++ b/src/Adapter/Service/CallbackFactory.php
@@ -12,13 +12,21 @@ namespace Zend\Paginator\Adapter\Service;
 use Interop\Container\ContainerInterface;
 use Zend\Paginator\Adapter\Callback;
 use Zend\ServiceManager\Exception\ServiceNotCreatedException;
-use Zend\ServiceManager\Factory\FactoryInterface;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
 
 /**
  * Create and return an instance of the Callback adapter.
  */
 class CallbackFactory implements FactoryInterface
 {
+    /**
+     * Options to use when creating adapter (v2)
+     *
+     * @var null|array
+     */
+    protected $creationOptions;
+
     /**
      * {@inheritDoc}
      *
@@ -37,5 +45,29 @@ class CallbackFactory implements FactoryInterface
         $itemsCallback = array_shift($options);
         $countCallback = array_shift($options);
         return new Callback($itemsCallback, $countCallback);
+    }
+
+    /**
+     * Create and return a Callback instance (v2)
+     *
+     * @param ServiceLocatorInterface $container
+     * @param null|string $name
+     * @param string $requestedName
+     * @return Callback
+     */
+    public function createService(ServiceLocatorInterface $container, $name = null, $requestedName = Callback::class)
+    {
+        return $this($container, $requestedName, $this->creationOptions);
+    }
+
+    /**
+     * Options to use with factory (v2)
+     *
+     * @param array $creationOptions
+     * @return void
+     */
+    public function setCreationOptions(array $creationOptions)
+    {
+        $this->creationOptions = $creationOptions;
     }
 }

--- a/src/Adapter/Service/DbSelectFactory.php
+++ b/src/Adapter/Service/DbSelectFactory.php
@@ -9,22 +9,63 @@
 
 namespace Zend\Paginator\Adapter\Service;
 
-use Zend\ServiceManager\Factory\FactoryInterface;
 use Interop\Container\ContainerInterface;
+use Zend\Paginator\Adapter\DbSelect;
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
 
 class DbSelectFactory implements FactoryInterface
 {
     /**
+     * Options to use when creating adapter (v2)
+     *
+     * @var null|array
+     */
+    protected $creationOptions;
+
+    /**
      * {@inheritDoc}
      *
-     * @return \Zend\Paginator\Adapter\DbSelect
+     * @return DbSelect
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
+        if (null === $options || empty($options)) {
+            throw new ServiceNotCreatedException(sprintf(
+                '%s requires a minimum of zend-db Sql\Select and Adapter instance',
+                DbSelect::class
+            ));
+        }
+
         return new $requestedName(
             $options[0],
             $options[1],
             isset($options[2]) ? $options[2] : null
         );
+    }
+
+    /**
+     * Create and return a DbSelect instance (v2)
+     *
+     * @param ServiceLocatorInterface $container
+     * @param null|string $name
+     * @param string $requestedName
+     * @return DbSelect
+     */
+    public function createService(ServiceLocatorInterface $container, $name = null, $requestedName = DbSelect::class)
+    {
+        return $this($container, $requestedName, $this->creationOptions);
+    }
+
+    /**
+     * Options to use with factory (v2)
+     *
+     * @param array $creationOptions
+     * @return void
+     */
+    public function setCreationOptions(array $creationOptions)
+    {
+        $this->creationOptions = $creationOptions;
     }
 }

--- a/src/Adapter/Service/DbTableGatewayFactory.php
+++ b/src/Adapter/Service/DbTableGatewayFactory.php
@@ -9,11 +9,21 @@
 
 namespace Zend\Paginator\Adapter\Service;
 
-use Zend\ServiceManager\Factory\FactoryInterface;
 use Interop\Container\ContainerInterface;
+use Zend\Paginator\Adapter\DbTableGateway;
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
 
 class DbTableGatewayFactory implements FactoryInterface
 {
+    /**
+     * Options to use when creating adapter (v2)
+     *
+     * @var null|array
+     */
+    protected $creationOptions;
+
     /**
      * {@inheritDoc}
      *
@@ -21,6 +31,13 @@ class DbTableGatewayFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
+        if (null === $options || empty($options)) {
+            throw new ServiceNotCreatedException(sprintf(
+                '%s requires a minimum of a zend-db TableGateway instance',
+                DbTableGateway::class
+            ));
+        }
+
         return new $requestedName(
             $options[0],
             isset($options[1]) ? $options[1] : null,
@@ -28,5 +45,32 @@ class DbTableGatewayFactory implements FactoryInterface
             isset($options[3]) ? $options[3] : null,
             isset($options[4]) ? $options[4] : null
         );
+    }
+
+    /**
+     * Create and return a DbTableGateway instance (v2)
+     *
+     * @param ServiceLocatorInterface $container
+     * @param null|string $name
+     * @param string $requestedName
+     * @return DbTableGateway
+     */
+    public function createService(
+        ServiceLocatorInterface $container,
+        $name = null,
+        $requestedName = DbTableGateway::class
+    ) {
+        return $this($container, $requestedName, $this->creationOptions);
+    }
+
+    /**
+     * Options to use with factory (v2)
+     *
+     * @param array $creationOptions
+     * @return void
+     */
+    public function setCreationOptions(array $creationOptions)
+    {
+        $this->creationOptions = $creationOptions;
     }
 }

--- a/src/Adapter/Service/IteratorFactory.php
+++ b/src/Adapter/Service/IteratorFactory.php
@@ -9,13 +9,73 @@
 
 namespace Zend\Paginator\Adapter\Service;
 
+use Iterator;
 use Interop\Container\ContainerInterface;
-use Zend\ServiceManager\Factory\FactoryInterface;
+use Zend\Paginator\Iterator as IteratorAdapter;
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
 
 class IteratorFactory implements FactoryInterface
 {
+    /**
+     * Options to use when creating adapter (v2)
+     *
+     * @var null|array
+     */
+    protected $creationOptions;
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return IteratorAdapter
+     */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
-        return (count($options) === 0) ? new $requestedName : new $requestedName($options[0]);
+        if (null === $options || empty($options)) {
+            throw new ServiceNotCreatedException(sprintf(
+                '%s requires a minimum of an Iterator instance',
+                IteratorAdapter::class
+            ));
+        }
+
+        $iterator = array_shift($options);
+
+        if (! $iterator instanceof Iterator) {
+            throw new ServiceNotCreatedException(sprintf(
+                '%s requires an Iterator instance; received %s',
+                IteratorAdapter::class,
+                (is_object($iterator) ? get_class($iterator) : gettype($iterator))
+            ));
+        }
+
+        return new $requestedName($iterator);
+    }
+
+    /**
+     * Create and return an IteratorAdapter instance (v2)
+     *
+     * @param ServiceLocatorInterface $container
+     * @param null|string $name
+     * @param string $requestedName
+     * @return IteratorAdapter
+     */
+    public function createService(
+        ServiceLocatorInterface $container,
+        $name = null,
+        $requestedName = IteratorAdapter::class
+    ) {
+        return $this($container, $requestedName, $this->creationOptions);
+    }
+
+    /**
+     * Options to use with factory (v2)
+     *
+     * @param array $creationOptions
+     * @return void
+     */
+    public function setCreationOptions(array $creationOptions)
+    {
+        $this->creationOptions = $creationOptions;
     }
 }

--- a/src/AdapterPluginManager.php
+++ b/src/AdapterPluginManager.php
@@ -10,6 +10,7 @@
 namespace Zend\Paginator;
 
 use Zend\ServiceManager\AbstractPluginManager;
+use Zend\ServiceManager\Exception\InvalidServiceException;
 use Zend\ServiceManager\Factory\InvokableFactory;
 
 /**
@@ -31,12 +32,22 @@ class AdapterPluginManager extends AbstractPluginManager
      */
     protected $aliases = [
         'callback'       => Adapter\Callback::class,
+        'Callback'       => Adapter\Callback::class,
         'dbselect'       => Adapter\DbSelect::class,
+        'dbSelect'       => Adapter\DbSelect::class,
+        'DbSelect'       => Adapter\DbSelect::class,
         'dbtablegateway' => Adapter\DbTableGateway::class,
+        'dbTableGateway' => Adapter\DbTableGateway::class,
+        'DbTableGateway' => Adapter\DbTableGateway::class,
         'null'           => Adapter\NullFill::class,
+        'Null'           => Adapter\NullFill::class,
         'nullfill'       => Adapter\NullFill::class,
+        'nullFill'       => Adapter\NullFill::class,
+        'NullFill'       => Adapter\NullFill::class,
         'array'          => Adapter\ArrayAdapter::class,
-        'iterator'       => Adapter\Iterator::class
+        'Array'          => Adapter\ArrayAdapter::class,
+        'iterator'       => Adapter\Iterator::class,
+        'Iterator'       => Adapter\Iterator::class,
     ];
 
     /**
@@ -50,8 +61,53 @@ class AdapterPluginManager extends AbstractPluginManager
         Adapter\DbTableGateway::class => Adapter\Service\DbTableGatewayFactory::class,
         Adapter\NullFill::class       => InvokableFactory::class,
         Adapter\Iterator::class       => Adapter\Service\IteratorFactory::class,
-        Adapter\ArrayAdapter::class   => InvokableFactory::class
+        Adapter\ArrayAdapter::class   => InvokableFactory::class,
+
+        // v2 normalized names
+
+        'zendpaginatoradaptercallback'       => Adapter\Service\CallbackFactory::class,
+        'zendpaginatoradapterdbselect'       => Adapter\Service\DbSelectFactory::class,
+        'zendpaginatoradapterdbtablegateway' => Adapter\Service\DbTableGatewayFactory::class,
+        'zendpaginatoradapternullfill'       => InvokableFactory::class,
+        'zendpaginatoradapteriterator'       => Adapter\Service\IteratorFactory::class,
+        'zendpaginatoradapterarrayadapter'   => InvokableFactory::class,
     ];
 
     protected $instanceOf = Adapter\AdapterInterface::class;
+
+    /**
+     * Validate that a plugin is an adapter (v3)
+     *
+     * @param mixed $plugin
+     * @throws InvalidServiceException
+     */
+    public function validate($plugin)
+    {
+        if (! $plugin instanceof $this->instanceOf) {
+            throw new InvalidServiceException(sprintf(
+                'Plugin of type %s is invalid; must implement %s',
+                (is_object($plugin) ? get_class($plugin) : gettype($plugin)),
+                Adapter\AdapterInterface::class
+            ));
+        }
+    }
+
+    /**
+     * Validate that a plugin is an adapter (v2)
+     *
+     * @param mixed $plugin
+     * @throws Exception\RuntimeException
+     */
+    public function validatePlugin($plugin)
+    {
+        try {
+            $this->validate($plugin);
+        } catch (InvalidServiceException $e) {
+            throw new Exception\RuntimeException(
+                $e->getMessage(),
+                $e->getCode(),
+                $e
+            );
+        }
+    }
 }

--- a/src/ScrollingStylePluginManager.php
+++ b/src/ScrollingStylePluginManager.php
@@ -10,6 +10,7 @@
 namespace Zend\Paginator;
 
 use Zend\ServiceManager\AbstractPluginManager;
+use Zend\ServiceManager\Exception\InvalidServiceException;
 use Zend\ServiceManager\Factory\InvokableFactory;
 
 /**
@@ -34,7 +35,7 @@ class ScrollingStylePluginManager extends AbstractPluginManager
         'jumping' => ScrollingStyle\Jumping::class,
         'Jumping' => ScrollingStyle\Jumping::class,
         'sliding' => ScrollingStyle\Sliding::class,
-        'Sliding' => ScrollingStyle\Sliding::class
+        'Sliding' => ScrollingStyle\Sliding::class,
     ];
 
     /**
@@ -46,8 +47,50 @@ class ScrollingStylePluginManager extends AbstractPluginManager
         ScrollingStyle\All::class     => InvokableFactory::class,
         ScrollingStyle\Elastic::class => InvokableFactory::class,
         ScrollingStyle\Jumping::class => InvokableFactory::class,
-        ScrollingStyle\Sliding::class => InvokableFactory::class
+        ScrollingStyle\Sliding::class => InvokableFactory::class,
+
+        // v2 normalized names
+        'zendpaginatorscrollingstyleall'     => InvokableFactory::class,
+        'zendpaginatorscrollingstyleelastic' => InvokableFactory::class,
+        'zendpaginatorscrollingstylejumping' => InvokableFactory::class,
+        'zendpaginatorscrollingstylesliding' => InvokableFactory::class,
     ];
 
     protected $instanceOf = ScrollingStyle\ScrollingStyleInterface::class;
+
+    /**
+     * Validate a plugin (v3)
+     *
+     * @param mixed $plugin
+     * @throws InvalidServiceException
+     */
+    public function validate($plugin)
+    {
+        if (! $plugin instanceof $this->instanceOf) {
+            throw new InvalidServiceException(sprintf(
+                'Plugin of type %s is invalid; must implement %s',
+                (is_object($plugin) ? get_class($plugin) : gettype($plugin)),
+                Adapter\AdapterInterface::class
+            ));
+        }
+    }
+
+    /**
+     * Validate a plugin (v2)
+     *
+     * @param mixed $plugin
+     * @throws Exception\InvalidArgumentException
+     */
+    public function validatePlugin($plugin)
+    {
+        try {
+            $this->validate($plugin);
+        } catch (InvalidServiceException $e) {
+            throw new Exception\InvalidArgumentException(
+                $e->getMessage(),
+                $e->getCode(),
+                $e
+            );
+        }
+    }
 }

--- a/test/AdapterPluginManagerCompatibilityTest.php
+++ b/test/AdapterPluginManagerCompatibilityTest.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zend-paginator for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Paginator;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use ReflectionProperty;
+use Zend\Paginator\AdapterPluginManager;
+use Zend\Paginator\Adapter\AdapterInterface;
+use Zend\Paginator\Exception\RuntimeException;
+use Zend\ServiceManager\ServiceManager;
+use Zend\ServiceManager\Test\CommonPluginManagerTrait;
+
+class AdapterPluginManagerCompatibilityTest extends TestCase
+{
+    use CommonPluginManagerTrait;
+
+    protected function getPluginManager()
+    {
+        return new AdapterPluginManager(new ServiceManager());
+    }
+
+    protected function getV2InvalidPluginException()
+    {
+        return RuntimeException::class;
+    }
+
+    protected function getInstanceOf()
+    {
+        return AdapterInterface::class;
+    }
+
+    public function aliasProvider()
+    {
+        $pluginManager = $this->getPluginManager();
+        $r = new ReflectionProperty($pluginManager, 'aliases');
+        $r->setAccessible(true);
+        $aliases = $r->getValue($pluginManager);
+
+        foreach ($aliases as $alias => $target) {
+            // Skipping as these have required arguments
+            if (strpos($target, '\\Db')) {
+                continue;
+            }
+
+            // Skipping as has required arguments
+            if (strpos($target, '\\Callback')) {
+                continue;
+            }
+
+            // Skipping as has required arguments
+            if (strpos($target, '\\Iterator')) {
+                continue;
+            }
+
+            yield $alias => [$alias, $target];
+        }
+    }
+}

--- a/test/AdapterPluginManagerTest.php
+++ b/test/AdapterPluginManagerTest.php
@@ -19,7 +19,6 @@ use Zend\Db\TableGateway\TableGateway;
 use Zend\Paginator\Adapter;
 use Zend\Paginator\AdapterPluginManager;
 use Zend\ServiceManager\ServiceManager;
-use Zend\Mvc\Service\ServiceManagerConfig;
 
 /**
  * @group      Zend_Paginator
@@ -103,21 +102,5 @@ class AdapterPluginManagerTest extends \PHPUnit_Framework_TestCase
 
         $plugin = $this->adapterPluginManager->get('callback', [$itemsCallback, $countCallback]);
         $this->assertInstanceOf(Adapter\Callback::class, $plugin);
-    }
-
-    public function testCanRetrievePluginManagerWithServiceManager()
-    {
-        $config = new ServiceManagerConfig([
-            'factories' => [
-                'PaginatorPluginManager'  => 'Zend\Mvc\Service\PaginatorPluginManagerFactory',
-            ],
-            'services' => [
-                'Config' => []
-            ]
-        ]);
-        $sm = $this->serviceManager = new ServiceManager($config->toArray());
-        //$sm->setService('Config', []);
-        $adapterPluginManager = $sm->get('PaginatorPluginManager');
-        $this->assertInstanceOf(AdapterPluginManager::class, $adapterPluginManager);
     }
 }

--- a/test/AdapterPluginManagerTest.php
+++ b/test/AdapterPluginManagerTest.php
@@ -18,7 +18,6 @@ use Zend\Db\Sql\Select;
 use Zend\Db\TableGateway\TableGateway;
 use Zend\Paginator\Adapter;
 use Zend\Paginator\AdapterPluginManager;
-use Zend\ServiceManager\ServiceManager;
 
 /**
  * @group      Zend_Paginator
@@ -27,7 +26,9 @@ class AdapterPluginManagerTest extends \PHPUnit_Framework_TestCase
 {
     protected $adapterPluginManager;
 
-    /** @var \PHPUnit_Framework_MockObject_MockObject */
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+    */
     protected $mockSelect;
 
     protected $mockAdapter;

--- a/test/FactoryTest.php
+++ b/test/FactoryTest.php
@@ -18,7 +18,9 @@ use ZendTest\Paginator\TestAsset\TestArrayAggregate;
  */
 class FactoryTest extends \PHPUnit_Framework_TestCase
 {
-    /** @var \PHPUnit_Framework_MockObject_MockObject */
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
     protected $mockSelect;
 
     protected $mockAdapter;

--- a/test/ScrollingStylePluginManagerCompatibilityTest.php
+++ b/test/ScrollingStylePluginManagerCompatibilityTest.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zend-paginator for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Paginator;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Paginator\ScrollingStylePluginManager;
+use Zend\Paginator\ScrollingStyle\ScrollingStyleInterface;
+use Zend\Paginator\Exception\InvalidArgumentException;
+use Zend\ServiceManager\ServiceManager;
+use Zend\ServiceManager\Test\CommonPluginManagerTrait;
+
+class ScrollingStylePluginManagerCompatibilityTest extends TestCase
+{
+    use CommonPluginManagerTrait;
+
+    protected function getPluginManager()
+    {
+        return new ScrollingStylePluginManager(new ServiceManager());
+    }
+
+    protected function getV2InvalidPluginException()
+    {
+        return InvalidArgumentException::class;
+    }
+
+    protected function getInstanceOf()
+    {
+        return ScrollingStyleInterface::class;
+    }
+}


### PR DESCRIPTION
Updates the code base to be forwards-compatible with zend-servicemanager v3 (and thus also zend-stdlib v3). In particular, it re-introduces v2-specific methods to all factories and plugin managers (as removed in #4 and #8), updates the plugin managers per the best practices we've uncovered during other migrations, and adds compatibility tests for plugin managers.ZZ
