### PR TITLE
Expose component as a config-provider / ZF component

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,10 @@
         "branch-alias": {
             "dev-master": "2.6-dev",
             "dev-develop": "2.7-dev"
+        },
+        "zf": {
+            "component": "Zend\\Paginator",
+            "config-provider": "Zend\\Paginator\\ConfigProvider"
         }
     },
     "autoload-dev": {

--- a/src/AdapterPluginManagerFactory.php
+++ b/src/AdapterPluginManagerFactory.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-paginator for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Paginator;
+
+use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class AdapterPluginManagerFactory implements FactoryInterface
+{
+    /**
+     * zend-servicemanager v2 support for invocation options.
+     *
+     * @param array
+     */
+    protected $creationOptions;
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return AdapterPluginManager
+     */
+    public function __invoke(ContainerInterface $container, $name, array $options = null)
+    {
+        return new AdapterPluginManager($container, $options ?: []);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return AdapterPluginManager
+     */
+    public function createService(ServiceLocatorInterface $container, $name = null, $requestedName = null)
+    {
+        return $this($container, $requestedName ?: AdapterPluginManager::class, $this->creationOptions);
+    }
+
+    /**
+     * zend-servicemanager v2 support for invocation options.
+     *
+     * @param array $options
+     * @return void
+     */
+    public function setCreationOptions(array $options)
+    {
+        $this->creationOptions = $options;
+    }
+}

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-paginator for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Paginator;
+
+class ConfigProvider
+{
+    /**
+     * Retrieve default zend-paginator configuration.
+     *
+     * @return array
+     */
+    public function __invoke()
+    {
+        return [
+            'dependencies' => $this->getDependencyConfig(),
+        ];
+    }
+
+    /**
+     * Retrieve dependency configuration for zend-paginator.
+     *
+     * @return array
+     */
+    public function getDependencyConfig()
+    {
+        return [
+            'factories' => [
+                AdapterPluginManager::class => AdapterPluginManagerFactory::class,
+                ScrollingStylePluginManager::class => ScrollingStylePluginManagerFactory::class,
+            ],
+        ];
+    }
+}

--- a/src/Module.php
+++ b/src/Module.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-paginator for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Paginator;
+
+class Module
+{
+    /**
+     * Retrieve default zend-paginator config for zend-mvc context.
+     *
+     * @return array
+     */
+    public function getConfig()
+    {
+        $provider = new ConfigProvider();
+        return [
+            'service_manager' => $provider->getDependencyConfig(),
+        ];
+    }
+}

--- a/src/ScrollingStylePluginManagerFactory.php
+++ b/src/ScrollingStylePluginManagerFactory.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-paginator for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Paginator;
+
+use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class ScrollingStylePluginManagerFactory implements FactoryInterface
+{
+    /**
+     * zend-servicemanager v2 support for invocation options.
+     *
+     * @param array
+     */
+    protected $creationOptions;
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return ScrollingStylePluginManager
+     */
+    public function __invoke(ContainerInterface $container, $name, array $options = null)
+    {
+        return new ScrollingStylePluginManager($container, $options ?: []);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return ScrollingStylePluginManager
+     */
+    public function createService(ServiceLocatorInterface $container, $name = null, $requestedName = null)
+    {
+        return $this($container, $requestedName ?: ScrollingStylePluginManager::class, $this->creationOptions);
+    }
+
+    /**
+     * zend-servicemanager v2 support for invocation options.
+     *
+     * @param array $options
+     * @return void
+     */
+    public function setCreationOptions(array $options)
+    {
+        $this->creationOptions = $options;
+    }
+}

--- a/test/AdapterPluginManagerFactoryTest.php
+++ b/test/AdapterPluginManagerFactoryTest.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-paginator for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Paginator;
+
+use Interop\Container\ContainerInterface;
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Paginator\Adapter\AdapterInterface;
+use Zend\Paginator\AdapterPluginManager;
+use Zend\Paginator\AdapterPluginManagerFactory;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class AdapterPluginManagerFactoryTest extends TestCase
+{
+    public function testFactoryReturnsPluginManager()
+    {
+        $container = $this->prophesize(ContainerInterface::class)->reveal();
+        $factory = new AdapterPluginManagerFactory();
+
+        $adapters = $factory($container, AdapterPluginManager::class);
+        $this->assertInstanceOf(AdapterPluginManager::class, $adapters);
+
+        if (method_exists($adapters, 'configure')) {
+            // zend-servicemanager v3
+            $this->assertAttributeSame($container, 'creationContext', $adapters);
+        } else {
+            // zend-servicemanager v2
+            $this->assertSame($container, $adapters->getServiceLocator());
+        }
+    }
+
+    /**
+     * @depends testFactoryReturnsPluginManager
+     */
+    public function testFactoryConfiguresPluginManagerUnderContainerInterop()
+    {
+        $container = $this->prophesize(ContainerInterface::class)->reveal();
+        $adapter = $this->prophesize(AdapterInterface::class)->reveal();
+
+        $factory = new AdapterPluginManagerFactory();
+        $adapters = $factory($container, AdapterPluginManager::class, [
+            'services' => [
+                'test' => $adapter,
+            ],
+        ]);
+        $this->assertSame($adapter, $adapters->get('test'));
+    }
+
+    /**
+     * @depends testFactoryReturnsPluginManager
+     */
+    public function testFactoryConfiguresPluginManagerUnderServiceManagerV2()
+    {
+        $container = $this->prophesize(ServiceLocatorInterface::class);
+        $container->willImplement(ContainerInterface::class);
+
+        $adapter = $this->prophesize(AdapterInterface::class)->reveal();
+
+        $factory = new AdapterPluginManagerFactory();
+        $factory->setCreationOptions([
+            'services' => [
+                'test' => $adapter,
+            ],
+        ]);
+
+        $adapters = $factory->createService($container->reveal());
+        $this->assertSame($adapter, $adapters->get('test'));
+    }
+}

--- a/test/ScrollingStylePluginManagerFactoryTest.php
+++ b/test/ScrollingStylePluginManagerFactoryTest.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-paginator for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Paginator;
+
+use Interop\Container\ContainerInterface;
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Paginator\ScrollingStylePluginManager;
+use Zend\Paginator\ScrollingStylePluginManagerFactory;
+use Zend\Paginator\ScrollingStyle\ScrollingStyleInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class ScrollingStylePluginManagerFactoryTest extends TestCase
+{
+    public function testFactoryReturnsPluginManager()
+    {
+        $container = $this->prophesize(ContainerInterface::class)->reveal();
+        $factory = new ScrollingStylePluginManagerFactory();
+
+        $scrollingStyles = $factory($container, ScrollingStylePluginManager::class);
+        $this->assertInstanceOf(ScrollingStylePluginManager::class, $scrollingStyles);
+
+        if (method_exists($scrollingStyles, 'configure')) {
+            // zend-servicemanager v3
+            $this->assertAttributeSame($container, 'creationContext', $scrollingStyles);
+        } else {
+            // zend-servicemanager v2
+            $this->assertSame($container, $scrollingStyles->getServiceLocator());
+        }
+    }
+
+    /**
+     * @depends testFactoryReturnsPluginManager
+     */
+    public function testFactoryConfiguresPluginManagerUnderContainerInterop()
+    {
+        $container = $this->prophesize(ContainerInterface::class)->reveal();
+        $scrollingStyle = $this->prophesize(ScrollingStyleInterface::class)->reveal();
+
+        $factory = new ScrollingStylePluginManagerFactory();
+        $scrollingStyles = $factory($container, ScrollingStylePluginManager::class, [
+            'services' => [
+                'test' => $scrollingStyle,
+            ],
+        ]);
+        $this->assertSame($scrollingStyle, $scrollingStyles->get('test'));
+    }
+
+    /**
+     * @depends testFactoryReturnsPluginManager
+     */
+    public function testFactoryConfiguresPluginManagerUnderServiceManagerV2()
+    {
+        $container = $this->prophesize(ServiceLocatorInterface::class);
+        $container->willImplement(ContainerInterface::class);
+
+        $scrollingStyle = $this->prophesize(ScrollingStyleInterface::class)->reveal();
+
+        $factory = new ScrollingStylePluginManagerFactory();
+        $factory->setCreationOptions([
+            'services' => [
+                'test' => $scrollingStyle,
+            ],
+        ]);
+
+        $scrollingStyles = $factory->createService($container->reveal());
+        $this->assertSame($scrollingStyle, $scrollingStyles->get('test'));
+    }
+}


### PR DESCRIPTION
Adds:
- Factories for each of:
  - `AdapterPluginManagerFactory`
  - `ScrollingStylePluginManagerFactory`
- `ConfigProvider`, which maps the two plugin managers to their factories.
- `Module`, which does the same, but for a zend-mvc context.
