### PR TITLE
Fixes #1 : paginator cache fix

### DIFF
--- a/src/Paginator.php
+++ b/src/Paginator.php
@@ -859,10 +859,7 @@ class Paginator implements Countable, IteratorAggregate
      */
     protected function _getCacheInternalId()
     {
-        return md5(serialize([
-            spl_object_hash($this->getAdapter()),
-            $this->getItemCountPerPage()
-        ]));
+        return md5(serialize($this->getAdapter()) . $this->getItemCountPerPage());
     }
 
     /**

--- a/test/PaginatorTest.php
+++ b/test/PaginatorTest.php
@@ -864,6 +864,14 @@ class PaginatorTest extends \PHPUnit_Framework_TestCase
         $outputGetCacheInternalId = $reflectionGetCacheInternalId->invoke($paginator);
 
         $this->assertEquals($outputGetCacheId, 'Zend_Paginator_1_' . $outputGetCacheInternalId);
+
+        $adapter = new TestAsset\TestAdapter;
+        $paginator = new Paginator\Paginator($adapter);
+        $reflectionGetCacheInternalId = new ReflectionMethod($paginator, '_getCacheInternalId');
+        $reflectionGetCacheInternalId->setAccessible(true);
+        $outputGetCacheInternalId = $reflectionGetCacheInternalId->invoke($paginator);
+
+        $this->assertEquals($outputGetCacheId, 'Zend_Paginator_1_' . $outputGetCacheInternalId);
     }
 
     /**


### PR DESCRIPTION
Fixes #1 . Also updated unit tests for `PaginatorTest::testGetCacheId()` with duplicate object creation to make it idempotent to check the affect of spl_object_hash removal.
