### PR TITLE
Fixes paginator cache, problem with the generation of cacheInternalId

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,4 +11,3 @@ site_name: zend-paginator
 site_description: zend-paginator
 repo_url: 'https://github.com/zendframework/zend-paginator'
 copyright: 'Copyright (c) 2016 <a href="http://www.zend.com/">Zend Technologies USA Inc.</a>'
-

--- a/src/Paginator.php
+++ b/src/Paginator.php
@@ -859,10 +859,13 @@ class Paginator implements Countable, IteratorAggregate
      */
     protected function _getCacheInternalId()
     {
-        return md5(serialize([
-            spl_object_hash($this->getAdapter()),
-            $this->getItemCountPerPage()
-        ]));
+        return md5(
+            json_encode(
+                get_object_vars($this->getAdapter())
+            ) . json_encode(
+                get_class_methods($this->getAdapter())
+            ) . $this->getItemCountPerPage()
+        );
     }
 
     /**

--- a/src/Paginator.php
+++ b/src/Paginator.php
@@ -860,10 +860,9 @@ class Paginator implements Countable, IteratorAggregate
     protected function _getCacheInternalId()
     {
         return md5(
-            json_encode(
-                get_object_vars($this->getAdapter())
-            ) . json_encode(
-                get_class_methods($this->getAdapter())
+            get_class($this->getAdapter())
+            . json_encode(
+                $this->getAdapter()
             ) . $this->getItemCountPerPage()
         );
     }

--- a/test/PaginatorTest.php
+++ b/test/PaginatorTest.php
@@ -876,14 +876,14 @@ class PaginatorTest extends \PHPUnit_Framework_TestCase
 
     public function testGetCacheIdWithSameAdapterAndDifferentAttributes()
     {
-        $adapter = new TestAsset\TestAdapter(array(1,2,3,4));
+        $adapter = new TestAsset\TestAdapter([1, 2, 3, 4]);
         $paginator = new Paginator\Paginator($adapter);
 
         $reflectionGetCacheInternalId = new ReflectionMethod($paginator, '_getCacheInternalId');
         $reflectionGetCacheInternalId->setAccessible(true);
         $firstOutputGetCacheInternalId = $reflectionGetCacheInternalId->invoke($paginator);
 
-        $adapter = new TestAsset\TestAdapter(array(1,2,3,4,5,6));
+        $adapter = new TestAsset\TestAdapter([1, 2, 3, 4, 5, 6]);
         $paginator = new Paginator\Paginator($adapter);
         $reflectionGetCacheInternalId = new ReflectionMethod($paginator, '_getCacheInternalId');
         $reflectionGetCacheInternalId->setAccessible(true);
@@ -893,14 +893,14 @@ class PaginatorTest extends \PHPUnit_Framework_TestCase
 
     public function testGetCacheIdWithInheritedClass()
     {
-        $adapter = new TestAsset\TestAdapter(array(1,2,3,4));
+        $adapter = new TestAsset\TestAdapter([1, 2, 3, 4]);
         $paginator = new Paginator\Paginator($adapter);
 
         $reflectionGetCacheInternalId = new ReflectionMethod($paginator, '_getCacheInternalId');
         $reflectionGetCacheInternalId->setAccessible(true);
         $firstOutputGetCacheInternalId = $reflectionGetCacheInternalId->invoke($paginator);
 
-        $adapter = new TestAsset\TestSimilarAdapter(array(1,2,3,4));
+        $adapter = new TestAsset\TestSimilarAdapter([1, 2, 3, 4]);
         $paginator = new Paginator\Paginator($adapter);
         $reflectionGetCacheInternalId = new ReflectionMethod($paginator, '_getCacheInternalId');
         $reflectionGetCacheInternalId->setAccessible(true);

--- a/test/PaginatorTest.php
+++ b/test/PaginatorTest.php
@@ -874,6 +874,40 @@ class PaginatorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($outputGetCacheId, 'Zend_Paginator_1_' . $outputGetCacheInternalId);
     }
 
+    public function testGetCacheIdWithSameAdapterAndDifferentAttributes()
+    {
+        $adapter = new TestAsset\TestAdapter(array(1,2,3,4));
+        $paginator = new Paginator\Paginator($adapter);
+
+        $reflectionGetCacheInternalId = new ReflectionMethod($paginator, '_getCacheInternalId');
+        $reflectionGetCacheInternalId->setAccessible(true);
+        $firstOutputGetCacheInternalId = $reflectionGetCacheInternalId->invoke($paginator);
+
+        $adapter = new TestAsset\TestAdapter(array(1,2,3,4,5,6));
+        $paginator = new Paginator\Paginator($adapter);
+        $reflectionGetCacheInternalId = new ReflectionMethod($paginator, '_getCacheInternalId');
+        $reflectionGetCacheInternalId->setAccessible(true);
+        $secondOutputGetCacheInternalId = $reflectionGetCacheInternalId->invoke($paginator);
+        $this->assertNotEquals($firstOutputGetCacheInternalId, $secondOutputGetCacheInternalId);
+    }
+
+    public function testGetCacheIdWithInheritedClass()
+    {
+        $adapter = new TestAsset\TestAdapter(array(1,2,3,4));
+        $paginator = new Paginator\Paginator($adapter);
+
+        $reflectionGetCacheInternalId = new ReflectionMethod($paginator, '_getCacheInternalId');
+        $reflectionGetCacheInternalId->setAccessible(true);
+        $firstOutputGetCacheInternalId = $reflectionGetCacheInternalId->invoke($paginator);
+
+        $adapter = new TestAsset\TestSimilarAdapter(array(1,2,3,4));
+        $paginator = new Paginator\Paginator($adapter);
+        $reflectionGetCacheInternalId = new ReflectionMethod($paginator, '_getCacheInternalId');
+        $reflectionGetCacheInternalId->setAccessible(true);
+        $secondOutputGetCacheInternalId = $reflectionGetCacheInternalId->invoke($paginator);
+        $this->assertNotEquals($firstOutputGetCacheInternalId, $secondOutputGetCacheInternalId);
+    }
+
     public function testAcceptsComplexAdapters()
     {
         $paginator = new Paginator\Paginator(

--- a/test/PaginatorTest.php
+++ b/test/PaginatorTest.php
@@ -864,6 +864,24 @@ class PaginatorTest extends \PHPUnit_Framework_TestCase
         $outputGetCacheInternalId = $reflectionGetCacheInternalId->invoke($paginator);
 
         $this->assertEquals($outputGetCacheId, 'Zend_Paginator_1_' . $outputGetCacheInternalId);
+
+        // After a re-creation of the same object, cacheId should remains the same
+        $adapter = new TestAsset\TestAdapter;
+        $paginator = new Paginator\Paginator($adapter);
+        $reflectionGetCacheInternalId = new ReflectionMethod($paginator, '_getCacheInternalId');
+        $reflectionGetCacheInternalId->setAccessible(true);
+        $outputGetCacheInternalId = $reflectionGetCacheInternalId->invoke($paginator);
+        $this->assertEquals($outputGetCacheId, 'Zend_Paginator_1_' . $outputGetCacheInternalId);
+    }
+
+    public function testAcceptsComplexAdapters()
+    {
+        $paginator = new Paginator\Paginator(
+            new TestAsset\TestAdapter(function () {
+                return 'test';
+            })
+        );
+        $this->assertInstanceOf('ArrayObject', $paginator->getCurrentItems());
     }
 
     /**

--- a/test/TestAsset/TestAdapter.php
+++ b/test/TestAsset/TestAdapter.php
@@ -16,6 +16,10 @@ class TestAdapter implements \Zend\Paginator\Adapter\AdapterInterface
      */
     public $property;
 
+    public $test = 100;
+
+    public $test2 = array (1,2,3);
+
     public function __construct($property = null)
     {
         $this->property = $property;

--- a/test/TestAsset/TestAdapter.php
+++ b/test/TestAsset/TestAdapter.php
@@ -9,8 +9,18 @@
 
 namespace ZendTest\Paginator\TestAsset;
 
-class TestAdapter extends \ArrayObject implements \Zend\Paginator\Adapter\AdapterInterface
+class TestAdapter implements \Zend\Paginator\Adapter\AdapterInterface
 {
+    /**
+     * @var mixed
+     */
+    public $property;
+
+    public function __construct($property = null)
+    {
+        $this->property = $property;
+    }
+
     public function count()
     {
         return 10;

--- a/test/TestAsset/TestAdapter.php
+++ b/test/TestAsset/TestAdapter.php
@@ -16,10 +16,6 @@ class TestAdapter implements \Zend\Paginator\Adapter\AdapterInterface
      */
     public $property;
 
-    public $test = 100;
-
-    public $test2 = array (1,2,3);
-
     public function __construct($property = null)
     {
         $this->property = $property;

--- a/test/TestAsset/TestSimilarAdapter.php
+++ b/test/TestAsset/TestSimilarAdapter.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Paginator\TestAsset;
+
+class TestSimilarAdapter extends TestAdapter implements \Zend\Paginator\Adapter\AdapterInterface
+{
+    public function differentFunction()
+    {
+        return "test";
+    }
+}


### PR DESCRIPTION
This fix also fixes a future problem with complex Adapters that cannot be serializable.
fixes #1 , joined the #24 and part of #30 , and included tests for both. 
Also, improved the method to get cacheInternalId to accept inherited adapter as well, without considering those the same adapters.