### PR TITLE
Prevent colliding internal cache ids based on adapter

### DIFF
--- a/src/Paginator.php
+++ b/src/Paginator.php
@@ -865,7 +865,7 @@ class Paginator implements Countable, IteratorAggregate
         // @codingStandardsIgnoreEnd
         return md5(
             get_class($this->getAdapter())
-            . json_encode($this->getAdapter())
+            . hash('sha512', print_r($this->getAdapter(), true))
             . $this->getItemCountPerPage()
         );
     }


### PR DESCRIPTION
Resolves #41 
`json_encode($this->getAdapter())` would always return an empty object for `\Zend\Paginator\Adapter\DbSelect` adapters (i.e. `{}`). By performing `print_r` on the adapter we can get the current state which, in the case of `DbSelect`, includes an sql object containing table name, join details, where clause, etc.
This change will prevent collisions between adapters that do not have any public properties and/or values.