### PR TITLE
DbSelectFactory correctly injects custom count select into adapter

### DIFF
--- a/src/Adapter/Service/DbSelectFactory.php
+++ b/src/Adapter/Service/DbSelectFactory.php
@@ -41,7 +41,8 @@ class DbSelectFactory implements FactoryInterface
         return new $requestedName(
             $options[0],
             $options[1],
-            isset($options[2]) ? $options[2] : null
+            isset($options[2]) ? $options[2] : null,
+            isset($options[3]) ? $options[3] : null
         );
     }
 

--- a/test/AdapterPluginManagerTest.php
+++ b/test/AdapterPluginManagerTest.php
@@ -119,17 +119,25 @@ class AdapterPluginManagerTest extends TestCase
         $mockResult    = $this->createMock(DbDriver\ResultInterface::class);
         $mockStatement = $this->createMock(DbDriver\StatementInterface::class);
 
-        $mockStatement->expects($this->any())->method('execute')->will($this->returnValue($mockResult));
+        $mockStatement
+            ->expects($this->any())
+            ->method('execute')
+            ->will($this->returnValue($mockResult));
 
         $mockSql = $this->getMockBuilder(Sql::class)
             ->setMethods(['prepareStatementForSqlObject'])
             ->disableOriginalConstructor()
             ->getMock();
 
-        $mockSql->expects($this->any())->method('prepareStatementForSqlObject')
-            ->with($mockSelectCount)->will($this->returnValue($mockStatement));
+        $mockSql
+            ->expects($this->any())
+            ->method('prepareStatementForSqlObject')
+            ->with($mockSelectCount)
+            ->will($this->returnValue($mockStatement));
 
-        $mockResult->expects($this->any())->method('current')
+        $mockResult
+            ->expects($this->any())
+            ->method('current')
             ->will($this->returnValue([Adapter\DbSelect::ROW_COUNT_COLUMN_NAME => 5]));
 
         $plugin = $this->adapterPluginManager->get(


### PR DESCRIPTION
Currently, the `DbSelectFactory` factory is unable to inject a count select into the constructor of the `DbSelect` class. This pull request fixes this issue.